### PR TITLE
Remove deprecated mixin

### DIFF
--- a/assets/scss/support/_mixins.scss
+++ b/assets/scss/support/_mixins.scss
@@ -13,10 +13,6 @@
         @if $underline {
             text-decoration: underline;
         }
-
-        @include hover-focus {
-            color: $hover-color;
-        }
     }
 }
 


### PR DESCRIPTION
See themes/docsy/assets/vendor/bootstrap/site/content/docs/4.3/migration.md

> - Removed `hover`, `hover-focus`, `plain-hover-focus`, and `hover-focus-active` mixins. Use regular CSS syntax for these moving forward. [See #28267](https://github.com/twbs/bootstrap/pull/28267).